### PR TITLE
Update Dockerfile env syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:19-alpine
 
-ENV NPM_CONFIG_LOGLEVEL error
+ENV NPM_CONFIG_LOGLEVEL=error
 
 RUN apk add --update bash
 


### PR DESCRIPTION
Fixes this warning:

```
------

 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 3)
Dockerfile:10
--------------------
   8 |
   9 |     COPY package*.json ./
  10 | >>> RUN npm install
  11 |
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
```