### PR TITLE
Add --legacy-peer-deps option to fix npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN apk add --update bash
 WORKDIR /code
 
 COPY package*.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps


### PR DESCRIPTION
Fixes this error

```
 => ERROR [5/5] RUN npm install                                                                                                                                                       0.9s
------
 > [5/5] RUN npm install:
0.840 npm notice
0.840 npm notice New major version of npm available! 9.6.3 -> 11.2.0
0.840 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v11.2.0>
0.840 npm notice Run `npm install -g npm@11.2.0` to update!
0.840 npm notice
0.844 npm ERR! code ERESOLVE
0.845 npm ERR! ERESOLVE could not resolve
0.845 npm ERR!
0.845 npm ERR! While resolving: ts-node@10.9.1
0.845 npm ERR! Found: typescript@5.0.0-beta
0.845 npm ERR! node_modules/typescript
0.845 npm ERR!   dev typescript@"5.0.0-beta" from the root project
0.846 npm ERR!   peer typescript@"*" from ts-loader@9.4.2
0.846 npm ERR!   node_modules/ts-loader
0.846 npm ERR!     ts-loader@"9.4.2" from the root project
0.846 npm ERR!
0.846 npm ERR! Could not resolve dependency:
0.846 npm ERR! peer typescript@">=2.7" from ts-node@10.9.1
0.846 npm ERR! node_modules/ts-node
0.846 npm ERR!   dev ts-node@"10.9.1" from the root project
0.846 npm ERR!
0.846 npm ERR! Conflicting peer dependency: typescript@5.8.2
0.846 npm ERR! node_modules/typescript
0.846 npm ERR!   peer typescript@">=2.7" from ts-node@10.9.1
0.846 npm ERR!   node_modules/ts-node
0.846 npm ERR!     dev ts-node@"10.9.1" from the root project
0.846 npm ERR!
0.846 npm ERR! Fix the upstream dependency conflict, or retry
0.846 npm ERR! this command with --force or --legacy-peer-deps
0.846 npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
0.846 npm ERR!
0.846 npm ERR!
0.846 npm ERR! For a full report see:
0.846 npm ERR! /root/.npm/_logs/2025-03-31T18_21_33_641Z-eresolve-report.txt
0.847
0.847 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2025-03-31T18_21_33_641Z-debug-0.log
------
Dockerfile:10
--------------------
   8 |
   9 |     COPY package*.json ./
  10 | >>> RUN npm install
  11 |
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install" did not complete successfully: exit code: 1
```